### PR TITLE
ECP-7: Meetings, Rules, and Regulations for Council

### DIFF
--- a/site/content/post/ecp7.md
+++ b/site/content/post/ecp7.md
@@ -2,7 +2,7 @@
 title: (Open) ECP-7, Meetings, Rules, and Regulations for Council
 date: 2020-02-17T00:00:10.000Z # Change the date and time
 description: >-
-Standardize council meeting so they are more effective and have rules/regulations on how the council operates.
+               Standardize council meeting so they are more effective and have rules/regulations on how the council operates.
 ---
 
 ECP Originator: CableGod

--- a/site/content/post/ecp7.md
+++ b/site/content/post/ecp7.md
@@ -1,3 +1,10 @@
+---
+title: (Open) ECP-7, Meetings, Rules, and Regulations for Council
+date: 2020-02-17T00:00:10.000Z # Change the date and time
+description: >-
+Standardize council meeting so they are more effective and have rules/regulations on how the council operates.
+---
+
 ECP Originator: CableGod
 ECP Sponsor: CableGod
 ECP Motivation: Standardize council meeting so they are more effective and have rules/regulations on how the council operates.

--- a/site/content/post/ecp7.md
+++ b/site/content/post/ecp7.md
@@ -1,0 +1,44 @@
+ECP Originator: CableGod
+ECP Sponsor: CableGod
+ECP Motivation: Standardize council meeting so they are more effective and have rules/regulations on how the council operates.
+ECP Summary: Unified way to run a meeting and create rules/regulations for council.
+Discussion: 17 Feb. 2020 00:01 UTC to 24 Feb. 2020 00:01 UTC
+Voting: 17 Feb. 2020 00:01 UTC to 24 Feb. 2020 00:01 UTC
+
+Basic Meeting Rules:
+  - Each meeting requires at least 4 votes and 3 members attending to move forward
+      - If 5 minutes after the meeting should have started and these guideline are not met then the  meeting ends with the meeting automatically re-scheduled the following week
+  - Meetings will be public for anyone to listen but only the council will be able to talk/discuss/vote
+  - If you are not available to attend the meeting you can proxy your vote to another member so they can vote for you. Proxy votes must be declared in the #team-council chat and a person can only proxy for a single person.
+  - The meeting agenda is created before the meeting where any council member can add discussion points, ECP proposals, etc for the next meeting. 2 days prior to the meeting changes to this document are closed. This document is currently to live on bit.ai.
+  - Any motion brought forward requires support of at least one member (commonly known as a "second") to move forward to a vote
+  - A vote of non-confidence for a council member can be brought forward at anytime but does require 6 votes to pass
+  - A meeting shall not last any longer than 1 hour and any remaining items will automatically be pushed to the next meeting. At the 1 hour mark a motion to extend the meeting can be made but will require votes from all meeting members to pass.
+  
+Meeting Order:
+  - Start meeting recording
+  - Make sure there is enough votes to continue meeting
+    - If not enough votes are available through member/proxy the meeting is re-scheduled for the following week and the recording made public on discord
+  - Choose Chair of Meeting (Runs the meeting)
+  - Go Through General Discussion Points
+    - Vote on any actionable discussions that are seconded by at least on member
+  - Go Through ECP Proposals
+    - Any ECP's with support on at least one can move forward and be placed on github for open discussion
+  - Go Through and ECP Voting (Any ECP's that have been discussed on github)
+    - Any ECP that passed voting have been ratified and any failed ECP's removed/closed.
+  - Call for Any Motions (Remove Member, Change Meeting Time, Schedule new Meeting)
+    - Any motions with at least one supporter are voted on
+    - Motion to remove member needs 6 votes to pass
+    - Motion to extend meeting time passed 1 hour requires all votes of members in the meeting
+- Meeting Concludes and the recorded call made public on discord
+
+Key Changes:
+  - ECP's now require to be proposed at a meeting before being placed on github
+  - ECP voting is now done at a meeting and not on github
+  - If a community member wants to bring foward an ECP they have to get a council member to back it and propose it in a meeting
+  - Rules around proxy votes
+  - Rules around votingg a council member out
+  - Rules on how to run a meeting
+  
+Actions After Passed:
+  - Schedule first two meetings (2 weeks apart) with each accommodating different timezones.


### PR DESCRIPTION
ECP Originator: CableGod
ECP Sponsor: CableGod
ECP Motivation: Standardize council meeting so they are more effective and have rules/regulations on how the council operates.
ECP Summary: Unified way to run a meeting and create rules/regulations for the council.
Discussion: 17 Feb. 2020 00:01 UTC to 24 Feb. 2020 00:01 UTC
Voting: 17 Feb. 2020 00:01 UTC to 24 Feb. 2020 00:01 UTC

Basic Meeting Rules:
  - Each meeting requires at least 4 votes and 3 members attending to move forward
      - If 5 minutes after the meeting should have started and these guidelines are not met then the  meeting ends with the meeting automatically re-scheduled the following week
  - Meetings will be public for anyone to listen but only the council will be able to talk/discuss/vote
  - If you are not available to attend the meeting you can proxy your vote to another member so they can vote for you. Proxy votes must be declared in the #team-council chat and a person can only proxy for a single person.
  - The meeting agenda is created before the meeting where any council member can add discussion points, ECP proposals, etc for the next meeting. 2 days prior to the meeting changes to this document are closed. This document is currently to live on bit.ai.
  - Any motion brought forward requires support of at least one member (commonly known as a "second") to move forward to a vote
  - A vote of non-confidence for a council member can be brought forward at anytime but does require 6 votes to pass
  - A meeting shall not last any longer than 1 hour and any remaining items will automatically be pushed to the next meeting. At the 1 hour mark a motion to extend the meeting can be made but will require votes from all meeting members to pass.
  
Meeting Order:
  - Start meeting recording
  - Make sure there is enough votes to continue meeting
    - If not enough votes are available through member/proxy the meeting is rescheduled for the following week and the recording made public on discord
  - Choose Chair of Meeting (Runs the meeting)
  - Go Through General Discussion Points
    - Vote on any actionable discussions that are seconded by at least one member
  - Go Through ECP Proposals
    - Any ECP's with support on at least one can move forward and be placed on github for open discussion
  - Go Through and ECP Voting (Any ECP's that have been discussed on github)
    - Any ECP that passed voting has been ratified and any failed ECP's removed/closed.
  - Call for Any Motions (Remove Member, Change Meeting Time, Schedule new Meeting)
    - Any motions with at least one supporter are voted on
    - Motion to remove member needs 6 votes to pass
    - Motion to extend meeting time passed 1 hour requires all votes of members in the meeting
- Meeting Concludes and the recorded call made public on discord

Key Changes:
  - ECP's now require to be proposed at a meeting before being placed on github
  - ECP voting is now done at a meeting and not on github
  - If a community member wants to bring forward an ECP they have to get a council member to back it and propose it in a meeting
  - Rules around proxy votes
  - Rules around voting a council member out
  - Rules on how to run a meeting
  
Actions After Passed:
  - Schedule the first two meetings (2 weeks apart) with each accommodating different timezones.