### PR TITLE
ECP-10: Operational Funding Version 1

### DIFF
--- a/site/content/post/ecp10.md
+++ b/site/content/post/ecp10.md
@@ -1,0 +1,25 @@
+---
+title: (Open) ECP-10 Operational Funding Version 1
+date: 2020-02-25T00:00:10.000Z # Change the date and time
+description: >-
+                Pay for project hardware operational expenses.
+---
+
+**ECP Originator:** `@Primate of $ETHO (ID: 393479955956367370)`
+**ECP Sponsor:** `@CableGod | Ether-1 (ID: 140537599604424704)`
+**ECP Motivation:** Pay for monthly hardware costs to keep project running. The funding will change over time as services are further decentralized.
+**ECP Summary:** Pay for project hardware operational expenses.
+**Discussion:** 25 Feb. 2020 14:00 UTC to 28 Mar. 2020 14:00 UTC  
+**Voting:** 25 Feb. 2020 14:00 UTC to 28 Mar. 2020 14:00 UTC
+
+## Details:
+This ECP is quick and straight to the point.  The operational costs of the project have been summarized in the Private Council in Discord to equal a total of $143.52.
+_The exact calculation of the costs is withheld for operational security reasons. In the future all attempts will be made to further de-obfuscate the operation costs funding_
+
+Operational costs for January and February are owed to Dev-James' wallet: `0x603a74A412367141D0ce61D5e77BF268F6B61983`
+
+Going forward, monthly payments will be made on the first of the Month or within the first 4 days of each month at the latest. After 4 days pass, each additional day the payments are late will incur a late fee of 1000 ETHO per day. This is to ensure payments are always made on time by the council.
+
+Payment can be initiated by any council member, without the need for second. The initiating council member is responsible for notifying the other council members that a payment for project hardware operation expenses is pending. Each month, the paying council member will estimate the payment of USD 143.52 equivalent value in ETHO according to the current market price average between all exchanges. The council member should post their calculation for verification and transparency. It is the responsibility of all council members to make sure only 1 regular monthly payment is made exactly agreed herein.
+
+By the end of 2020, the funding of project hardware operational expenses will change as some council people choose to take up responsibility for hosting some of the services, always with the #DecentralizeEverything idea in mind. This ECP may also change due to changing of providers. Any change of the amount project hardware operational expenses needs to have a new ECP input and approved before payments change to the new amount.

--- a/site/content/post/ecp10.md
+++ b/site/content/post/ecp10.md
@@ -1,5 +1,5 @@
 ---
-title: (Open) ECP-10 Operational Funding Version 1
+title: (Approved) ECP-10 Operational Funding Version 1
 date: 2020-02-25T00:00:10.000Z # Change the date and time
 description: >-
                 Pay for project hardware operational expenses.


### PR DESCRIPTION
**ECP Originator:** `@Primate of $ETHO (ID: 393479955956367370)`
**ECP Sponsor:** `@CableGod | Ether-1 (ID: 140537599604424704)`
**ECP Motivation:** Pay for monthly hardware costs to keep project running. The funding will change over time as services are further decentralized.
**ECP Summary:** Pay for project hardware operational expenses.
**Discussion:** 25 Feb. 2020 14:00 UTC to 28 Mar. 2020 14:00 UTC  
**Voting:** 25 Feb. 2020 14:00 UTC to 28 Mar. 2020 14:00 UTC

## Details:
This ECP is quick and straight to the point.  The operational costs of the project have been summarized in the Private Council in Discord to equal a total of $143.52.
_The exact calculation of the costs is withheld for operational security reasons. In the future all attempts will be made to further de-obfuscate the operation costs funding_

Operational costs for January and February are owed to Dev-James' wallet: `0x603a74A412367141D0ce61D5e77BF268F6B61983`

Going forward, monthly payments will be made on the first of the Month or within the first 4 days of each month at the latest. After 4 days pass, each additional day the payments are late will incur a late fee of 1000 ETHO per day. This is to ensure payments are always made on time by the council.

Payment can be initiated by any council member, without the need for second. The initiating council member is responsible for notifying the other council members that a payment for project hardware operation expenses is pending. Each month, the paying council member will estimate the payment of USD 143.52 equivalent value in ETHO according to the current market price average between all exchanges. The council member should post their calculation for verification and transparency. It is the responsibility of all council members to make sure only 1 regular monthly payment is made exactly as agreed herein.

By the end of 2020, the funding of project hardware operational expenses will change as some council people choose to take up responsibility for hosting some of the services, always with the #DecentralizeEverything idea in mind. This ECP may also change due to changing of providers. Any change of the amount project hardware operational expenses needs to have a new ECP input and approved before payments change to the new amount.