### PR TITLE
ECP-13: Ether-1 Councilperson Inactivity Standard

### DIFF
--- a/site/content/post/ecp13.md
+++ b/site/content/post/ecp13.md
@@ -1,0 +1,22 @@
+---
+title: (Open) ECP-13 Ether-1 Councilperson Inactivity Standard
+date: 2020-07-19T13:00:00.000Z # Change the date and time
+description: >-
+                Define Ether-1 councilperson inactivity standards so that the council can be rotated more easily, making sure active and passionate people are in charge.
+---
+
+ECP-13 - ECP-13 Ether-1 Councilperson Inactivity Standard
+ECP Originator: @Primate of $ETHO (ID: 393479955956367370)
+ECP Sponsor: 
+ECP Motivation: Ensure Ether-1 council members are always active within a reasonable time frame to keep the project moving forward
+ECP Summary: Define Ether-1 councilperson inactivity standards so that the council can be rotated more easily, making sure active and passionate people are in charge.
+Discussion: 19 Jul. 2020 to 26 Jul. 2020
+Voting: 19 Jul. 2020 to 26 Jul. 2020
+
+Details:
+This is a short ECP intended to put simple inactivity metrics for council members so they can be rotated with fresh members as needed to keep the project running smoothly.
+
+An Ether-1 councilperson shall be considered inactive and eligible for a replacement vote if all of the following conditions are true:
+- Councilperson has not signed a funding transaction in the last 3 months
+- Councilperson has not seconded or personally authored an ECP in the last 3 months
+- Councilperson ...

--- a/site/content/post/ecp13.md
+++ b/site/content/post/ecp13.md
@@ -14,9 +14,11 @@ Discussion: 19 Jul. 2020 to 26 Jul. 2020
 Voting: 19 Jul. 2020 to 26 Jul. 2020
 
 Details:
-This is a short ECP intended to put simple inactivity metrics for council members so they can be rotated with fresh members as needed to keep the project running smoothly.
+This is a short ECP intended to put simple inactivity metrics for council members so they can be rotated with fresh members as needed to keep the project running smoothly. This ECP is intended to be modified in the future when activity standards change with the circumstances and a higher threshold for activity is necessary for the good of the project.
 
 An Ether-1 councilperson shall be considered inactive and eligible for a replacement vote if 2/3 of the following conditions are true within the last 3 month period:
 - Councilperson has not signed a funding transaction
 - Councilperson has not seconded or personally authored an ECP
 - Councilperson has not been active in Discord or Telegram
+
+When the inactivity criteria is met, any active council member has the option of initiating a vote to replace the inactive member(s) with new members. The logistics of the voting process are to follow the latest official rules set forth by the council. After the vote has ended and a new council member or members is/are elected, the ECP fund shall vote in the new member(s) wallets.

--- a/site/content/post/ecp13.md
+++ b/site/content/post/ecp13.md
@@ -18,7 +18,7 @@ This is a short ECP intended to put simple inactivity metrics for council member
 
 An Ether-1 councilperson shall be considered inactive and eligible for a replacement vote if 2/3 of the following conditions are true within the last 3 month period:
 - Councilperson has not signed a funding transaction
-- Councilperson has not seconded or personally authored an ECP
-- Councilperson has not been active in Discord or Telegram
+- Councilperson has not seconded or personally authored an ECP and has not voted on ECPs
+- Councilperson has not been active in Discord, related to governance matters (discussing ECP's, funding, rules, etc.; popping in to say hello does not count as activity) 
 
 When the inactivity criteria is met, any active council member has the option of initiating a vote to replace the inactive member(s) with new members. The logistics of the voting process are to follow the latest official rules set forth by the council. After the vote has ended and a new council member or members is/are elected, the ECP fund shall vote in the new member(s) wallets.

--- a/site/content/post/ecp13.md
+++ b/site/content/post/ecp13.md
@@ -16,7 +16,7 @@ Voting: 19 Jul. 2020 to 26 Jul. 2020
 Details:
 This is a short ECP intended to put simple inactivity metrics for council members so they can be rotated with fresh members as needed to keep the project running smoothly.
 
-An Ether-1 councilperson shall be considered inactive and eligible for a replacement vote if all of the following conditions are true:
-- Councilperson has not signed a funding transaction in the last 3 months
-- Councilperson has not seconded or personally authored an ECP in the last 3 months
-- Councilperson ...
+An Ether-1 councilperson shall be considered inactive and eligible for a replacement vote if 2/3 of the following conditions are true within the last 3 month period:
+- Councilperson has not signed a funding transaction
+- Councilperson has not seconded or personally authored an ECP
+- Councilperson has not been active in Discord or Telegram


### PR DESCRIPTION
ECP-13: Ether-1 Councilperson Inactivity Standard
ECP Discussion/Vote Date Start | End: 19 Jul. 2020 to 26 Jul. 2020 to 19 Jul. 2020 to 26 Jul. 2020 UTC

ECP Originator: @Primate411 
ECP Sponsor: @dylie 
ECP Motivation: Ensure Ether-1 council members are always active within a reasonable time frame to keep the project moving forward
ECP Summary: Define Ether-1 councilperson inactivity standards so that the council can be rotated more easily, making sure active and passionate people are in charge.

Details:
This is a short ECP intended to put simple inactivity metrics for council members so they can be rotated with fresh members as needed to keep the project running smoothly. This ECP is intended to be modified in the future when activity standards change with the circumstances and a higher threshold for activity is necessary for the good of the project.

An Ether-1 councilperson shall be considered inactive and eligible for a replacement vote if 2/3 of the following conditions are true within the last 3 month period:
- Councilperson has not signed a funding transaction
- Councilperson has not seconded or personally authored an ECP and has not voted on ECPs
- Councilperson has not been active in Discord, related to governance matters (discussing ECP's, funding, rules, etc.; popping in to say hello does not count as activity) 

When the inactivity criteria is met, any active council member has the option of initiating a vote to replace the inactive member(s) with new members. The logistics of the voting process are to follow the latest official rules set forth by the council. After the vote has ended and a new council member or members is/are elected, the ECP fund shall vote in the new member(s) wallets.
